### PR TITLE
Correct address of Swift demo

### DIFF
--- a/themes.yml
+++ b/themes.yml
@@ -278,7 +278,7 @@
 - title: Swift
   home_url: https://github.com/pranavrajs/swift
   download_url: https://github.com/pranavrajs/swift/archive/master.zip
-  demo_url: http://pranavrajs.me/swift
+  demo_url: https://pranavrajs.github.io/swift/
   author: Pranav Raj S
   thumbnail: swift.png
   license: MIT


### PR DESCRIPTION
The link to Swift theme demo was pointing to a domain that does not exist. I found the correct demo address. Here's a fix.